### PR TITLE
Scaling camera projections by overscan

### DIFF
--- a/src/render/camera.cpp
+++ b/src/render/camera.cpp
@@ -391,9 +391,9 @@ void Camera::update(Scene *scene)
        * calculation above.
        */
       ProjectionTransform screentocamera_pre = projection_inverse(
-          projection_perspective(fov_pre, nearclip, farclip));
+          projection_perspective(fov_pre, nearclip, farclip, overscan));
       ProjectionTransform screentocamera_post = projection_inverse(
-          projection_perspective(fov_post, nearclip, farclip));
+          projection_perspective(fov_post, nearclip, farclip, overscan));
 
       kcam->perspective_pre = screentocamera_pre * rastertoscreen;
       kcam->perspective_post = screentocamera_post * rastertoscreen;

--- a/src/render/camera.cpp
+++ b/src/render/camera.cpp
@@ -270,7 +270,7 @@ void Camera::update(Scene *scene)
   /* screen to camera */
   ProjectionTransform cameratoscreen;
   if (type == CAMERA_PERSPECTIVE)
-    cameratoscreen = projection_perspective(fov, nearclip, farclip);
+    cameratoscreen = projection_perspective(fov, nearclip, farclip, overscan);
   else if (type == CAMERA_ORTHOGRAPHIC)
     cameratoscreen = projection_orthographic(nearclip, farclip, overscan);
   else

--- a/src/render/camera.cpp
+++ b/src/render/camera.cpp
@@ -198,6 +198,8 @@ Camera::Camera() : Node(node_type)
   dx = make_float3(0.0f, 0.0f, 0.0f);
   dy = make_float3(0.0f, 0.0f, 0.0f);
 
+  overscan = 0.f;
+
   need_update = true;
   need_device_update = true;
   need_flags_update = true;
@@ -270,7 +272,7 @@ void Camera::update(Scene *scene)
   if (type == CAMERA_PERSPECTIVE)
     cameratoscreen = projection_perspective(fov, nearclip, farclip);
   else if (type == CAMERA_ORTHOGRAPHIC)
-    cameratoscreen = projection_orthographic(nearclip, farclip);
+    cameratoscreen = projection_orthographic(nearclip, farclip, overscan);
   else
     cameratoscreen = projection_identity();
 

--- a/src/render/camera.h
+++ b/src/render/camera.h
@@ -160,6 +160,8 @@ class Camera : public Node {
   float3 frustum_right_normal;
   float3 frustum_top_normal;
 
+  float overscan;
+
   /* update */
   bool need_update;
   bool need_device_update;

--- a/src/util/util_projection.h
+++ b/src/util/util_projection.h
@@ -189,12 +189,12 @@ ccl_device_inline void print_projection(const char *label, const ProjectionTrans
   printf("\n");
 }
 
-ccl_device_inline ProjectionTransform projection_perspective(float fov, float n, float f)
+ccl_device_inline ProjectionTransform projection_perspective(float fov, float n, float f, float overscan = 0.f)
 {
   ProjectionTransform persp = make_projection(
       1, 0, 0, 0, 0, 1, 0, 0, 0, 0, f / (f - n), -f * n / (f - n), 0, 0, 1, 0);
 
-  float inv_angle = 1.0f / tanf(0.5f * fov);
+  float inv_angle = (1.0f / (1.0f + overscan * 2.0f)) / tanf(0.5f * fov);
 
   Transform scale = transform_scale(inv_angle, inv_angle, 1);
 

--- a/src/util/util_projection.h
+++ b/src/util/util_projection.h
@@ -201,9 +201,9 @@ ccl_device_inline ProjectionTransform projection_perspective(float fov, float n,
   return scale * persp;
 }
 
-ccl_device_inline ProjectionTransform projection_orthographic(float znear, float zfar)
+ccl_device_inline ProjectionTransform projection_orthographic(float znear, float zfar, float overscan = 0.f)
 {
-  Transform t = transform_scale(1.0f, 1.0f, 1.0f / (zfar - znear)) *
+  Transform t = transform_scale(1.0f / (1.0f + overscan), 1.0f / (1.0f + overscan), 1.0f / (zfar - znear)) *
                 transform_translate(0.0f, 0.0f, -znear);
 
   return ProjectionTransform(t);

--- a/src/util/util_projection.h
+++ b/src/util/util_projection.h
@@ -203,7 +203,8 @@ ccl_device_inline ProjectionTransform projection_perspective(float fov, float n,
 
 ccl_device_inline ProjectionTransform projection_orthographic(float znear, float zfar, float overscan = 0.f)
 {
-  Transform t = transform_scale(1.0f / (1.0f + overscan), 1.0f / (1.0f + overscan), 1.0f / (zfar - znear)) *
+  const float scale = 1.0f / (1.0f + overscan);
+  Transform t = transform_scale(scale, scale, 1.0f / (zfar - znear)) *
                 transform_translate(0.0f, 0.0f, -znear);
 
   return ProjectionTransform(t);

--- a/src/util/util_projection.h
+++ b/src/util/util_projection.h
@@ -189,7 +189,10 @@ ccl_device_inline void print_projection(const char *label, const ProjectionTrans
   printf("\n");
 }
 
-ccl_device_inline ProjectionTransform projection_perspective(float fov, float n, float f, float overscan = 0.f)
+ccl_device_inline ProjectionTransform projection_perspective(float fov,
+                                                             float n,
+                                                             float f,
+                                                             float overscan = 0.0f)
 {
   ProjectionTransform persp = make_projection(
       1, 0, 0, 0, 0, 1, 0, 0, 0, 0, f / (f - n), -f * n / (f - n), 0, 0, 1, 0);
@@ -201,7 +204,9 @@ ccl_device_inline ProjectionTransform projection_perspective(float fov, float n,
   return scale * persp;
 }
 
-ccl_device_inline ProjectionTransform projection_orthographic(float znear, float zfar, float overscan = 0.f)
+ccl_device_inline ProjectionTransform projection_orthographic(float znear,
+                                                              float zfar,
+                                                              float overscan = 0.0f)
 {
   const float scale = 1.0f / (1.0f + overscan);
   Transform t = transform_scale(scale, scale, 1.0f / (zfar - znear)) *


### PR DESCRIPTION
Added `overscan` option to camera which scales the screen to camera projection by the overscan amount.

Perspective projection could be handled outside the renderer by tweaking the field of view, but scaling for orthographic projections requires a new parameter from what I can see. So I used it for both projections.
