### PR TITLE
Decouple transform and deform motion blur steps

### DIFF
--- a/src/kernel/geom/geom_object.h
+++ b/src/kernel/geom/geom_object.h
@@ -78,7 +78,7 @@ ccl_device_inline Transform object_fetch_transform_motion(KernelGlobals *kg,
 {
   const uint motion_offset = kernel_tex_fetch(__objects, object).motion_offset;
   const ccl_global DecomposedTransform *motion = &kernel_tex_fetch(__object_motion, motion_offset);
-  const uint num_steps = kernel_tex_fetch(__objects, object).numsteps * 2 + 1;
+  const uint num_steps = kernel_tex_fetch(__objects, object).num_tfm_steps;
 
   Transform tfm;
   transform_motion_array_interpolate(&tfm, motion, num_steps, time);
@@ -305,7 +305,7 @@ ccl_device_inline void object_motion_info(
   }
 
   if (numsteps)
-    *numsteps = kernel_tex_fetch(__objects, object).numsteps;
+    *numsteps = kernel_tex_fetch(__objects, object).num_dfm_steps;
   if (numverts)
     *numverts = kernel_tex_fetch(__objects, object).numverts;
 }

--- a/src/kernel/kernel_types.h
+++ b/src/kernel/kernel_types.h
@@ -1523,8 +1523,9 @@ typedef struct KernelObject {
   float dupli_uv[2];
 
   int numkeys;
-  int numsteps;
   int numverts;
+  uint16_t num_tfm_steps;
+  uint16_t num_dfm_steps;
 
   uint patch_map_offset;
   uint attribute_map_offset;

--- a/src/render/object.cpp
+++ b/src/render/object.cpp
@@ -536,7 +536,8 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
   kobject.dupli_uv[0] = ob->dupli_uv[0];
   kobject.dupli_uv[1] = ob->dupli_uv[1];
   int totalsteps = geom->motion_steps;
-  kobject.numsteps = (totalsteps - 1) / 2;
+  kobject.num_dfm_steps = (totalsteps - 1) / 2;
+  kobject.num_tfm_steps = ob->motion.size();
   kobject.numverts = (geom->type == Geometry::MESH) ? static_cast<Mesh *>(geom)->verts.size() : 0;
   kobject.patch_map_offset = 0;
   kobject.attribute_map_offset = 0;


### PR DESCRIPTION
Transformation and deformation motion blur were already very
independent, with the exception that they both used the same variable
to hold the number of steps.

They are now separated, deformation blur uses an explicit variable
in ccl::Geometry, transformation blur is implicit in the size of the
ccl::Object::motion array.