### PR TITLE
Microfacet BSDF zero normal fix

### DIFF
--- a/src/kernel/closure/bsdf_microfacet_multi.h
+++ b/src/kernel/closure/bsdf_microfacet_multi.h
@@ -483,6 +483,12 @@ ccl_device int bsdf_microfacet_multi_ggx_sample(KernelGlobals *kg,
 {
   const MicrofacetBsdf *bsdf = (const MicrofacetBsdf *)sc;
 
+  if (len(bsdf->N) < FLT_EPSILON) {
+    *eval = make_float3(.0f);
+    *pdf = 0.0f;
+    return LABEL_NONE;
+  }
+
   float3 X, Y, Z;
   Z = bsdf->N;
 

--- a/src/kernel/closure/bsdf_microfacet_multi.h
+++ b/src/kernel/closure/bsdf_microfacet_multi.h
@@ -483,7 +483,7 @@ ccl_device int bsdf_microfacet_multi_ggx_sample(KernelGlobals *kg,
 {
   const MicrofacetBsdf *bsdf = (const MicrofacetBsdf *)sc;
 
-  if (len(bsdf->N) < FLT_EPSILON) {
+  if (len_squared(bsdf->N) < FLT_EPSILON) {
     *eval = make_float3(.0f);
     *pdf = 0.0f;
     return LABEL_NONE;


### PR DESCRIPTION
This PR adds an early exit for microfacet bsdf sample in the case of a zero normal, which causes omega_in to become NaN and causes problems in the evaluation of other bsdfs. 

Fixes Freshdesk issue 8070.