### PR TITLE
Prevent null pointer dereference when generating motion blur geometry

### DIFF
--- a/src/render/geometry.cpp
+++ b/src/render/geometry.cpp
@@ -1921,6 +1921,8 @@ void GeometryManager::create_motion_blur_geometry(
 
   /* If we don't have anything to generate motion blur with, we just disable it */
   if (!attr_V && !attr_A) {
+    geom->motion_steps = 1;
+    geom->use_motion_blur = false;
     return;
   }
 

--- a/src/render/geometry.cpp
+++ b/src/render/geometry.cpp
@@ -1919,10 +1919,7 @@ void GeometryManager::create_motion_blur_geometry(
     A = attr_A->data_float3();
   }
 
-  /* If we don't have anything to generate motion blur with, we just disable it */
   if (!attr_V && !attr_A) {
-    geom->motion_steps = 1;
-    geom->use_motion_blur = false;
     return;
   }
 

--- a/src/render/geometry.cpp
+++ b/src/render/geometry.cpp
@@ -1919,6 +1919,11 @@ void GeometryManager::create_motion_blur_geometry(
     A = attr_A->data_float3();
   }
 
+  /* If we don't have anything to generate motion blur with, we just disable it */
+  if (!attr_V && !attr_A) {
+    return;
+  }
+
   /* Rounding up to include center step */
   geom->motion_steps += (geom->motion_steps % 2) ? 0 : 1;
 


### PR DESCRIPTION
Exiting the function if no accelerations nor velocities are present. This was happening for meshes generated from volumes with motion blur.

Closes freshdesk ticket #8171