### PR TITLE
Consistent lock order: display first, buffers second.

### DIFF
--- a/src/render/session.cpp
+++ b/src/render/session.cpp
@@ -671,8 +671,8 @@ void Session::run_cpu()
       if (!pause && delayed_reset.do_reset) {
         /* reset once to start */
         thread_scoped_lock reset_lock(delayed_reset.mutex);
-        thread_scoped_lock buffers_lock(buffers_mutex);
         thread_scoped_lock display_lock(display_mutex);
+        thread_scoped_lock buffers_lock(buffers_mutex);
 
         reset_(delayed_reset.params, delayed_reset.samples);
         delayed_reset.do_reset = false;
@@ -740,8 +740,8 @@ void Session::run_cpu()
 
     {
       thread_scoped_lock reset_lock(delayed_reset.mutex);
-      thread_scoped_lock buffers_lock(buffers_mutex);
       thread_scoped_lock display_lock(display_mutex);
+      thread_scoped_lock buffers_lock(buffers_mutex);
 
       if (delayed_reset.do_reset) {
         /* reset rendering if request from main thread */


### PR DESCRIPTION
The inconsistent order in which the display and the buffer mutex were used could lead to occasional dead locks in the Houdini viewport.