### PR TITLE
OIDN build from rez

### DIFF
--- a/package.py
+++ b/package.py
@@ -2,7 +2,7 @@
 
 name = 'cycles'
 
-version = '1.13.0-ta.1.13.0'
+version = '1.13.0-ta.1.14.0'
 
 authors = [
     'benjamin.skinner',
@@ -19,6 +19,7 @@ requires = [
     'openexr-2.4.0',
     'embree-3.8.0',
     'nanovdb-29.3.0',
+    'oidn-1.4.1',
 
     # Only needed for logging
     'glog-0.4.0',

--- a/src/cmake/CyclesConfig.cmake.in
+++ b/src/cmake/CyclesConfig.cmake.in
@@ -47,6 +47,7 @@ target_include_directories(Cycles::Cycles SYSTEM
     "@TBB_INCLUDE_DIRS@" # Tbb
     "@GLEW_INCLUDE_DIR@" # GLEW
     "@OPENJPEG_INCLUDE_DIR@" # OpenJPEG
+    "@OPENIMAGEDENOISE_INCLUDE_DIR@" # OpenImageDenoise
     )
 
 target_link_libraries(Cycles::Cycles 
@@ -67,6 +68,7 @@ target_link_libraries(Cycles::Cycles
     "@TBB_LIBRARIES@" # Tbb
     "@GLEW_LIBRARY@" # GLEW
     "@OPENJPEG_LIBRARY@" # OpenJPEG
+    "@OPENIMAGEDENOISE_LIBRARIES@" # OpenImageDenoise
     )
 
 if(@WITH_CYCLES_LOGGING@)

--- a/src/cmake/rez_deps.cmake
+++ b/src/cmake/rez_deps.cmake
@@ -80,6 +80,13 @@ else()
     set(WITH_CYCLES_EMBREE OFF CACHE BOOL "Build Cycles with embree support" FORCE)
 endif()
 
+if(DEFINED ENV{REZ_OIDN_BASE})
+    message("WITH REZ OIDN")
+    set(WITH_CYCLES_OPENIMAGEDENOISE ON CACHE BOOL "Build Cycles with OpenImageDenoise support" FORCE)
+else()
+    set(WITH_CYCLES_OPENIMAGEDENOISE OFF CACHE BOOL "Build Cycles with OpenImageDenoise support" FORCE)
+endif()
+
 set(WITH_CYCLES_DEBUG OFF CACHE BOOL "Build Cycles with with extra debug capabilties" FORCE)
 
 set(WITH_CYCLES_CUDA_BINARIES OFF CACHE BOOL "Build Cycles CUDA binaries" FORCE)


### PR DESCRIPTION
- We can build against OIDN
- Not super urgent, but good to have if we want the renderer to denoise instead of a post-process (that we will ultimately use instead)