### PR TITLE
Missing LIGHTGROUPS_NONE

### DIFF
--- a/src/render/light.cpp
+++ b/src/render/light.cpp
@@ -290,7 +290,7 @@ void LightManager::device_update_distribution(Device *,
   size_t num_triangles = 0;
 
   bool background_mis = false;
-  uint lightgroup = 0;
+  uint lightgroup = LIGHTGROUPS_NONE;
 
   foreach (Light *light, scene->lights) {
     if (light->is_enabled) {
@@ -922,7 +922,7 @@ void LightManager::device_update_points(Device *, DeviceScene *dscene, Scene *sc
       klights[light_index].lightgroup = it->second;
     }
     else {
-      klights[light_index].lightgroup = 0;
+      klights[light_index].lightgroup = LIGHTGROUPS_NONE;
     }
 
     light_index++;

--- a/src/render/object.cpp
+++ b/src/render/object.cpp
@@ -569,6 +569,8 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
   auto it = scene->lightgroups.find(ob->lightgroup);
   if (it != scene->lightgroups.end()) {
     kobject.lightgroup = it->second;
+  } else {
+    kobject.lightgroup = LIGHTGROUPS_NONE;
   }
 }
 


### PR DESCRIPTION
Fixes a crash where the light group isn't set to 'LIGHTGROUPS_NONE' in the kernel code when there's no matching AOV and it will try to index with random numbers and crash (oops).