### PR TITLE
TextureInfo early exit 

### DIFF
--- a/package.py
+++ b/package.py
@@ -2,7 +2,7 @@
 
 name = 'cycles'
 
-version = '1.13.0-ta.1.14.2'
+version = '1.13.0-ta.1.14.3'
 
 authors = [
     'benjamin.skinner',

--- a/package.py
+++ b/package.py
@@ -2,7 +2,7 @@
 
 name = 'cycles'
 
-version = '1.13.0-ta.1.14.1'
+version = '1.13.0-ta.1.14.2'
 
 authors = [
     'benjamin.skinner',

--- a/src/kernel/kernel_compat_cpu.h
+++ b/src/kernel/kernel_compat_cpu.h
@@ -116,6 +116,7 @@ template<typename T> struct texture {
 #define kernel_tex_fetch_ssei(tex, index) (kg->tex.fetch_ssei(index))
 #define kernel_tex_lookup(tex, t, offset, size) (kg->tex.lookup(t, offset, size))
 #define kernel_tex_array(tex) (kg->tex.data)
+#define kernel_tex_width(tex) (kg->tex.width)
 
 #define kernel_data (kg->__data)
 

--- a/src/kernel/svm/svm_image.h
+++ b/src/kernel/svm/svm_image.h
@@ -30,6 +30,11 @@ ccl_device float4 svm_image_texture(KernelGlobals *kg,
         TEX_IMAGE_MISSING_R, TEX_IMAGE_MISSING_G, TEX_IMAGE_MISSING_B, TEX_IMAGE_MISSING_A);
   }
 
+  if (id >= kernel_tex_width(__texture_info)) {
+    return make_float4(
+        TEX_IMAGE_MISSING_R, TEX_IMAGE_MISSING_G, TEX_IMAGE_MISSING_B, TEX_IMAGE_MISSING_A);
+  }
+
   float4 r = kernel_tex_image_interp(kg, id, x, y, ds, dt, path_flag);
   const float alpha = r.w;
 


### PR DESCRIPTION
In some cases when artist create a shading network with invalid uvs set name, Cycles crashes because `id` is out of bounds. This fix introduces early exit and return invalid colour.