### PR TITLE
Instanced attributes sets

### DIFF
--- a/src/kernel/geom/geom_attribute.h
+++ b/src/kernel/geom/geom_attribute.h
@@ -87,7 +87,8 @@ ccl_device_inline AttributeDescriptor find_attribute(KernelGlobals *kg,
 
   /* Offset the index by the instance number */
   if (desc.flags & ATTR_INSTANCED) {
-    const int instance_index = kernel_tex_fetch(__objects, sd->object).particle_index;
+    const int instance_index = kernel_tex_fetch(__objects, sd->object).instance_index;
+    
     if (desc.element == ATTR_ELEMENT_VERTEX || desc.element == ATTR_ELEMENT_VERTEX_MOTION) {
       desc.offset += instance_index * kernel_tex_fetch(__objects, sd->object).numverts;
     } else if (desc.element == ATTR_ELEMENT_CORNER || desc.element == ATTR_ELEMENT_CORNER_MOTION) {

--- a/src/kernel/geom/geom_attribute.h
+++ b/src/kernel/geom/geom_attribute.h
@@ -85,9 +85,21 @@ ccl_device_inline AttributeDescriptor find_attribute(KernelGlobals *kg,
   desc.type = (NodeAttributeType)(attr_map.w & 0xff);
   desc.flags = (AttributeFlag)(attr_map.w >> 8);
 
+  /* Offset the index by the instance number */
   if (desc.flags & ATTR_INSTANCED) {
-    desc.offset += kernel_tex_fetch(__objects, sd->object).particle_index;
-    // printf("REQUESTING INSTANCED ATTRIBUTES %d particle id %d type %d size %d\n", (int)id, particle_id, desc.type,(int) size);
+    const int instance_index = kernel_tex_fetch(__objects, sd->object).particle_index;
+    if (desc.element == ATTR_ELEMENT_VERTEX || desc.element == ATTR_ELEMENT_VERTEX_MOTION) {
+      desc.offset += instance_index * kernel_tex_fetch(__objects, sd->object).numverts;
+    } else if (desc.element == ATTR_ELEMENT_CORNER || desc.element == ATTR_ELEMENT_CORNER_MOTION) {
+      /* todo(Edoardo): Implement once we have internal subdivision surfaces  */
+      desc.offset += instance_index * kernel_tex_fetch(__objects, sd->object).numfaces * 3;
+    } else if (desc.element == ATTR_ELEMENT_FACE) {
+      desc.offset += instance_index * kernel_tex_fetch(__objects, sd->object).numfaces;
+    } else if (desc.element == ATTR_ELEMENT_CURVE_KEY) {
+      desc.offset += instance_index * kernel_tex_fetch(__objects, sd->object).numkeys;
+    } else {
+      desc.offset += instance_index;
+    }
   }
 
   return desc;

--- a/src/kernel/geom/geom_attribute.h
+++ b/src/kernel/geom/geom_attribute.h
@@ -85,6 +85,11 @@ ccl_device_inline AttributeDescriptor find_attribute(KernelGlobals *kg,
   desc.type = (NodeAttributeType)(attr_map.w & 0xff);
   desc.flags = (AttributeFlag)(attr_map.w >> 8);
 
+  if (desc.flags & ATTR_INSTANCED) {
+    desc.offset += kernel_tex_fetch(__objects, sd->object).particle_index;
+    // printf("REQUESTING INSTANCED ATTRIBUTES %d particle id %d type %d size %d\n", (int)id, particle_id, desc.type,(int) size);
+  }
+
   return desc;
 }
 

--- a/src/kernel/geom/geom_motion_point.h
+++ b/src/kernel/geom/geom_motion_point.h
@@ -46,7 +46,7 @@ ccl_device_inline int find_attribute_point_motion(KernelGlobals *kg,
 
 ccl_device_inline float4 motion_point_attribute_for_step(KernelGlobals *kg,
                                                          int offset,
-                                                         int numkeys,
+                                                         int numverts,
                                                          int numsteps,
                                                          int step,
                                                          int prim,
@@ -62,7 +62,7 @@ ccl_device_inline float4 motion_point_attribute_for_step(KernelGlobals *kg,
     if (step > numsteps)
       step--;
 
-    offset += step * numkeys;
+    offset += step * numverts;
 
     return kernel_tex_fetch(__attributes_float3, offset + prim);
   }
@@ -78,8 +78,8 @@ ccl_device_inline float4 motion_point_attribute(KernelGlobals *kg,
                                                 int attr)
 {
   /* get motion info */
-  int numsteps, numkeys;
-  object_motion_info(kg, object, &numsteps, NULL, &numkeys);
+  int numsteps, numverts;
+  object_motion_info(kg, object, &numsteps, &numverts, NULL);
 
   /* figure out which steps we need to fetch and their interpolation factor */
   int maxstep = numsteps * 2;
@@ -93,9 +93,9 @@ ccl_device_inline float4 motion_point_attribute(KernelGlobals *kg,
 
   /* fetch key coordinates */
   float4 point_attr = motion_point_attribute_for_step(
-      kg, offset, numkeys, numsteps, step, prim, n_points_attrs, attr);
+      kg, offset, numverts, numsteps, step, prim, n_points_attrs, attr);
   float4 next_point_attr = motion_point_attribute_for_step(
-      kg, offset, numkeys, numsteps, step + 1, prim, n_points_attrs, attr);
+      kg, offset, numverts, numsteps, step + 1, prim, n_points_attrs, attr);
 
   /* interpolate between steps */
   return (1.0f - t) * point_attr + t * next_point_attr;

--- a/src/kernel/kernel_types.h
+++ b/src/kernel/kernel_types.h
@@ -1540,6 +1540,7 @@ typedef struct KernelObject {
   uint16_t num_tfm_steps;
   uint16_t num_dfm_steps;
 
+  uint instance_index;
   uint patch_map_offset;
   uint attribute_map_offset;
   uint motion_offset;
@@ -1551,7 +1552,6 @@ typedef struct KernelObject {
   float cryptomatte_asset;
 
   float shadow_terminator_offset;
-  float pad2;
 } KernelObject;
 static_assert_align(KernelObject, 16);
 

--- a/src/kernel/kernel_types.h
+++ b/src/kernel/kernel_types.h
@@ -829,6 +829,7 @@ typedef enum AttributeStandard {
 typedef enum AttributeFlag {
   ATTR_FINAL_SIZE = (1 << 0),
   ATTR_SUBDIVIDED = (1 << 1),
+  ATTR_INSTANCED = (1 << 2)
 } AttributeFlag;
 
 typedef struct AttributeDescriptor {

--- a/src/kernel/kernel_types.h
+++ b/src/kernel/kernel_types.h
@@ -1535,7 +1535,8 @@ typedef struct KernelObject {
   float dupli_uv[2];
 
   int numkeys;
-  int numverts;
+  int numverts; /* Number of vertices in a mesh or points in a cloud */
+  int numfaces;
   uint16_t num_tfm_steps;
   uint16_t num_dfm_steps;
 
@@ -1550,7 +1551,7 @@ typedef struct KernelObject {
   float cryptomatte_asset;
 
   float shadow_terminator_offset;
-  float pad1, pad2;
+  float pad2;
 } KernelObject;
 static_assert_align(KernelObject, 16);
 

--- a/src/render/attribute.cpp
+++ b/src/render/attribute.cpp
@@ -168,12 +168,6 @@ size_t Attribute::element_size(Geometry *geom, AttributePrimitive prim) const
 
 size_t Attribute::buffer_size(Geometry *geom, AttributePrimitive prim) const
 {
-  if (instances > 1) {
-  std::cout << "Allocating attribute " << name << 
-    " element size " << element_size(geom, prim) <<
-    " data size " << data_sizeof() << 
-    " instances " << instances << std::endl;;
-  }
   return element_size(geom, prim) * data_sizeof() * instances;
 }
 

--- a/src/render/attribute.cpp
+++ b/src/render/attribute.cpp
@@ -338,8 +338,8 @@ void Attribute::get_uv_tiles(Geometry *geom,
 
 /* Attribute Set */
 
-AttributeSet::AttributeSet(Geometry *geometry, AttributePrimitive prim)
-    : geometry(geometry), prim(prim)
+AttributeSet::AttributeSet(Geometry *geometry, AttributePrimitive prim, uint instances)
+    : geometry(geometry), prim(prim), instances(instances)
 {
 }
 
@@ -347,7 +347,7 @@ AttributeSet::~AttributeSet()
 {
 }
 
-Attribute *AttributeSet::add(ustring name, TypeDesc type, AttributeElement element, uint instances)
+Attribute *AttributeSet::add(ustring name, TypeDesc type, AttributeElement element)
 {
   Attribute *attr = find(name);
 

--- a/src/render/attribute.cpp
+++ b/src/render/attribute.cpp
@@ -28,8 +28,8 @@ CCL_NAMESPACE_BEGIN
 /* Attribute */
 
 Attribute::Attribute(
-    ustring name, TypeDesc type, AttributeElement element, Geometry *geom, AttributePrimitive prim)
-    : name(name), std(ATTR_STD_NONE), type(type), element(element), flags(0)
+    ustring name, TypeDesc type, AttributeElement element, Geometry *geom, AttributePrimitive prim, uint instances)
+    : name(name), std(ATTR_STD_NONE), type(type), element(element), flags(0), instances(instances)
 {
   /* string and matrix not supported! */
   assert(type == TypeDesc::TypeFloat || type == TypeDesc::TypeColor ||
@@ -43,6 +43,10 @@ Attribute::Attribute(
   }
   else {
     resize(geom, prim, false);
+  }
+
+  if (instances > 1) {
+    flags |= ATTR_INSTANCED;
   }
 }
 
@@ -164,7 +168,13 @@ size_t Attribute::element_size(Geometry *geom, AttributePrimitive prim) const
 
 size_t Attribute::buffer_size(Geometry *geom, AttributePrimitive prim) const
 {
-  return element_size(geom, prim) * data_sizeof();
+  if (instances > 1) {
+  std::cout << "Allocating attribute " << name << 
+    " element size " << element_size(geom, prim) <<
+    " data size " << data_sizeof() << 
+    " instances " << instances << std::endl;;
+  }
+  return element_size(geom, prim) * data_sizeof() * instances;
 }
 
 bool Attribute::same_storage(TypeDesc a, TypeDesc b)
@@ -337,7 +347,7 @@ AttributeSet::~AttributeSet()
 {
 }
 
-Attribute *AttributeSet::add(ustring name, TypeDesc type, AttributeElement element)
+Attribute *AttributeSet::add(ustring name, TypeDesc type, AttributeElement element, uint instances)
 {
   Attribute *attr = find(name);
 
@@ -350,7 +360,7 @@ Attribute *AttributeSet::add(ustring name, TypeDesc type, AttributeElement eleme
     remove(name);
   }
 
-  Attribute new_attr(name, type, element, geometry, prim);
+  Attribute new_attr(name, type, element, geometry, prim, instances);
   attributes.emplace_back(std::move(new_attr));
   return &attributes.back();
 }

--- a/src/render/attribute.h
+++ b/src/render/attribute.h
@@ -179,11 +179,12 @@ class AttributeSet {
   Geometry *geometry;
   AttributePrimitive prim;
   list<Attribute> attributes;
+  uint instances;
 
-  AttributeSet(Geometry *geometry, AttributePrimitive prim);
+  AttributeSet(Geometry *geometry, AttributePrimitive prim, uint instances = 1);
   ~AttributeSet();
 
-  Attribute *add(ustring name, TypeDesc type, AttributeElement element, uint instances = 1);
+  Attribute *add(ustring name, TypeDesc type, AttributeElement element);
   Attribute *find(ustring name) const;
   void remove(ustring name);
 

--- a/src/render/attribute.h
+++ b/src/render/attribute.h
@@ -53,12 +53,14 @@ class Attribute {
   vector<char> buffer;
   AttributeElement element;
   uint flags; /* enum AttributeFlag */
+  uint instances;
 
   Attribute(ustring name,
             TypeDesc type,
             AttributeElement element,
             Geometry *geom,
-            AttributePrimitive prim);
+            AttributePrimitive prim,
+            uint instances = 1);
   Attribute(Attribute &&other) = default;
   Attribute(const Attribute &other) = delete;
   Attribute &operator=(const Attribute &other) = delete;
@@ -179,7 +181,7 @@ class AttributeSet {
   AttributeSet(Geometry *geometry, AttributePrimitive prim);
   ~AttributeSet();
 
-  Attribute *add(ustring name, TypeDesc type, AttributeElement element);
+  Attribute *add(ustring name, TypeDesc type, AttributeElement element, uint instances = 1);
   Attribute *find(ustring name) const;
   void remove(ustring name);
 

--- a/src/render/attribute.h
+++ b/src/render/attribute.h
@@ -53,6 +53,8 @@ class Attribute {
   vector<char> buffer;
   AttributeElement element;
   uint flags; /* enum AttributeFlag */
+
+  /* Multiplier on the size of the buffer */
   uint instances;
 
   Attribute(ustring name,

--- a/src/render/geometry.cpp
+++ b/src/render/geometry.cpp
@@ -1074,6 +1074,8 @@ void GeometryManager::fill_attributes_and_maps(Device *device,
     }
   }
 
+  std::cout << "Instance groups " << scene->instance_groups.size() << std::endl;
+
   for (size_t i = 0; i < scene->instance_groups.size(); ++i) {
     const size_t attribute_map_idx = scene->geometry.size() + i;
     Geometry *geom = scene->instance_groups[i]->attributes.geometry;
@@ -1179,8 +1181,10 @@ void GeometryManager::fill_attributes_and_maps(Device *device,
 
       /* If the attribute is authored on the geometry, avoid duplication */
       if (!attr) {
+        std::cout << "moo " << req.name << std::endl;
         req = attributes[geom->geometry_index].requests[attribute_req_idx];
       } else {
+        std::cout << "moo " << req.name << std::endl;
         update_attribute_element_offset(geom,
                                         dscene->attributes_float,
                                         attr_float_offset,

--- a/src/render/geometry.h
+++ b/src/render/geometry.h
@@ -86,6 +86,9 @@ class Geometry : public Node {
   bool need_update;
   bool need_update_rebuild;
 
+  /* Used by the geometry manager */
+  int geometry_index;
+
   /* Constructor/Destructor */
   explicit Geometry(const NodeType *node_type, const Type type);
   virtual ~Geometry();

--- a/src/render/geometry.h
+++ b/src/render/geometry.h
@@ -170,6 +170,8 @@ class GeometryManager {
   void collect_statistics(const Scene *scene, RenderStats *stats);
 
  protected:
+
+  /* Geometry  */
   bool displace(Device *device, DeviceScene *dscene, Scene *scene, Mesh *mesh, Progress &progress);
 
   void create_volume_mesh(Mesh *mesh, Progress &progress);
@@ -179,6 +181,12 @@ class GeometryManager {
   void create_motion_blur_geometry(const Scene *scene, Geometry *geom, Progress &progress);
 
   /* Attributes */
+  void fill_attributes_and_maps(Device *device,
+                                Scene *scene,
+                                DeviceScene *dscene,
+                                Progress &progress,
+                                vector<AttributeRequestSet> &attributes);
+
   void update_osl_attributes(Device *device,
                              Scene *scene,
                              vector<AttributeRequestSet> &geom_attributes);

--- a/src/render/instance_group.h
+++ b/src/render/instance_group.h
@@ -30,7 +30,7 @@ CCL_NAMESPACE_BEGIN
 class InstanceGroup {
 public:
   // todo(Edo): Implement subdivision surfaces once they are internal
-  InstanceGroup(Geometry* geom, uint instances) : attributes(geom, ATTR_PRIM_GEOMETRY, instances) { }
+  InstanceGroup(Geometry* geom, uint instances) : attributes(geom, ATTR_PRIM_GEOMETRY, instances), attr_map_offset(~0) { }
 
   AttributeSet attributes;
 

--- a/src/render/instance_group.h
+++ b/src/render/instance_group.h
@@ -1,0 +1,51 @@
+/*
+*  Copyright 2021 Tangent Animation
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+*  including without limitation, as related to merchantability and fitness
+*  for a particular purpose.
+*
+*  In no event shall any copyright holder be liable for any damages of any kind
+*  arising from the use of this software, whether in contract, tort or otherwise.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+#ifndef __INSTANCE_GROUP_H__
+#define __INSTANCE_GROUP_H__
+
+CCL_NAMESPACE_BEGIN
+
+// todo: forward declaration
+#include "geometry.h"
+
+/* Stores a set of attributes that can be indexed by individual objects 
+ * through Object::instance_index.
+ *
+ * Note: All objects that reference a certain instance group need to have
+ * the same geometry as stored in the instance group.
+ * 
+ * There is no InstanceManager, because the logic to upload attribute
+ * and respective maps is interwined with the geometry manager.
+ * */
+struct InstanceGroup {
+  // todo(Edo): An extra parameter might be needed once we have internal subdivision surfaces
+  InstanceGroup(Geometry* geom) : attributes(geom, ATTR_PRIM_GEOMETRY), geometry(geom) { }
+
+  AttributeSet attributes;
+  Geometry* geometry = nullptr;
+
+  /* Used by the geometry manager */
+  size_t attr_map_offset = 0;
+};
+
+CCL_NAMESPACE_END
+
+#endif /* __INSTANCE_GROUP_H__ */

--- a/src/render/instance_group.h
+++ b/src/render/instance_group.h
@@ -26,23 +26,15 @@ CCL_NAMESPACE_BEGIN
 // todo: forward declaration
 #include "geometry.h"
 
-/* Stores a set of attributes that can be indexed by individual objects 
- * through Object::instance_index.
- *
- * Note: All objects that reference a certain instance group need to have
- * the same geometry as stored in the instance group.
- * 
- * There is no InstanceManager, because the logic to upload attribute
- * and respective maps is interwined with the geometry manager.
- * */
+/* Set of attributes that can be indexed by individual objects 
+ * through Object::instance_index. */
 struct InstanceGroup {
-  // todo(Edo): An extra parameter might be needed once we have internal subdivision surfaces
-  InstanceGroup(Geometry* geom) : attributes(geom, ATTR_PRIM_GEOMETRY), geometry(geom) { }
+  // todo(Edo): subdivision surfaces
+  InstanceGroup(Geometry* geom) : attributes(geom, ATTR_PRIM_GEOMETRY) { }
 
   AttributeSet attributes;
-  Geometry* geometry = nullptr;
 
-  /* Used by the geometry manager */
+  /* Used internally by the geometry manager */
   size_t attr_map_offset = 0;
 };
 

--- a/src/render/instance_group.h
+++ b/src/render/instance_group.h
@@ -23,14 +23,14 @@
 
 CCL_NAMESPACE_BEGIN
 
-// todo: forward declaration
-#include "geometry.h"
+#include "render/geometry.h"
 
 /* Set of attributes that can be indexed by individual objects 
  * through Object::instance_index. */
-struct InstanceGroup {
-  // todo(Edo): subdivision surfaces
-  InstanceGroup(Geometry* geom) : attributes(geom, ATTR_PRIM_GEOMETRY) { }
+class InstanceGroup {
+public:
+  // todo(Edo): Implement subdivision surfaces once they are internal
+  InstanceGroup(Geometry* geom, uint instances) : attributes(geom, ATTR_PRIM_GEOMETRY, instances) { }
 
   AttributeSet attributes;
 

--- a/src/render/object.cpp
+++ b/src/render/object.cpp
@@ -769,7 +769,6 @@ void ObjectManager::device_update_flags(
 
 void ObjectManager::device_update_mesh_offsets(Device *, DeviceScene *dscene, Scene *scene)
 {
-  printf("Writing objects %d %d\n", (int)scene->objects.size(), (int)dscene->objects.size());
   if (dscene->objects.size() == 0) {
     return;
   }
@@ -795,7 +794,7 @@ void ObjectManager::device_update_mesh_offsets(Device *, DeviceScene *dscene, Sc
       }
     }
 
-    if (object->instance_group && object->instance_group->attr_map_offset > 0) {
+    if (object->instance_group && kobjects[object->index].attribute_map_offset != object->instance_group->attr_map_offset) {
       kobjects[object->index].attribute_map_offset = object->instance_group->attr_map_offset;
       update = true;
     } else if (kobjects[object->index].attribute_map_offset != geom->attr_map_offset) {

--- a/src/render/object.cpp
+++ b/src/render/object.cpp
@@ -475,6 +475,7 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
   kobject.random_number = random_number;
   kobject.particle_index = particle_index;
   kobject.instance_index = ob->instance_group ? ob->instance_index : 0;
+  assert(!ob->instance_group || ob->instance_index < ob->instance_group->attributes.instances);
   kobject.motion_offset = 0;
 
   if (geom->use_motion_blur) {

--- a/src/render/object.cpp
+++ b/src/render/object.cpp
@@ -473,9 +473,10 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
   kobject.color[2] = color.z;
   kobject.pass_id = pass_id;
   kobject.random_number = random_number;
-  kobject.particle_index = ob->particle_index;
+  kobject.particle_index = particle_index;
+  kobject.instance_index = ob->instance_group ? ob->instance_index : 0;
   kobject.motion_offset = 0;
-  
+
   if (geom->use_motion_blur) {
     state->have_motion = true;
   }

--- a/src/render/object.h
+++ b/src/render/object.h
@@ -30,6 +30,7 @@
 
 CCL_NAMESPACE_BEGIN
 
+class AttributeSet;
 class Device;
 class DeviceScene;
 class Geometry;
@@ -71,6 +72,11 @@ class Object : public Node {
 
   ParticleSystem *particle_system;
   int particle_index;
+
+  /* Additional set of attributes that can be accessed using
+   * the instance_index */
+  InstanceGroup* instance_group;
+  int instance_index;
 
   Object();
   ~Object();

--- a/src/render/object.h
+++ b/src/render/object.h
@@ -73,8 +73,8 @@ class Object : public Node {
   ParticleSystem *particle_system;
   int particle_index;
 
-  /* Additional set of attributes that can be accessed using
-   * the instance_index */
+  /* Additional set of attributes that takes precedence over
+   * Geometry's attributes and is indexable by each object. */
   InstanceGroup* instance_group;
   int instance_index;
 

--- a/src/render/scene.cpp
+++ b/src/render/scene.cpp
@@ -23,6 +23,7 @@
 #include "render/curves.h"
 #include "render/film.h"
 #include "render/integrator.h"
+#include "render/instance_group.h"
 #include "render/light.h"
 #include "render/mesh.h"
 #include "render/object.h"
@@ -140,9 +141,12 @@ void Scene::free_memory(bool final)
     delete l;
   foreach (ParticleSystem *p, particle_systems)
     delete p;
+  foreach (InstanceGroup* i, instance_groups)
+    delete i;
 
   shaders.clear();
   geometry.clear();
+  instance_groups.clear();
   objects.clear();
   lights.clear();
   particle_systems.clear();

--- a/src/render/scene.h
+++ b/src/render/scene.h
@@ -46,6 +46,7 @@ class LightManager;
 class LookupTables;
 class Geometry;
 class GeometryManager;
+class InstanceGroup;
 class Object;
 class ObjectManager;
 class ParticleSystemManager;
@@ -284,6 +285,7 @@ class Scene {
   vector<Shader *> shaders;
   vector<Light *> lights;
   vector<ParticleSystem *> particle_systems;
+  vector<InstanceGroup *> instance_groups;
 
   /* data managers */
   ImageManager *image_manager;


### PR DESCRIPTION
**Description**
This patch allows objects to read from and index shared attribute sets.
The logic in the geometry manager has been changed to allocate an extra device attribute map for each `InstanceGroup` which is essentially an alias for an `AttributeSet`. The attribute requests are fulfilled by the instanced attribute set, or the geometry attribute set if the former are not found. 

Design considerations are very welcome. One drawback of the current approach is that geometry attributes which are overwritten by instanced attributes are currently committed to the device. Skipping this commit requires knowing which attributes in the geometry attribute set are *always* overwritten by instanced attribute sets, requiring extra management logic. It could also be argued that adding those attribute to the geometry in the first place doesn't make a lot of sense and maybe the responsibility lies in the delegate.

**Changes**
- Added a vector of attribute sets at the scene level which can be referenced by objects
- Changed `Geometry::device_update` to combine geometry and instanced attribute sets
- `find_attribute` uses the per object `instance_index` to index the attributeset
- The kernel object for point clouds has switched to using numverts, rather than numkeys to match the interpolation 
ATTR_ELEMENT_VERTEX

**Test**
Here is a test file 
[perpoint_attr.zip](https://github.com/tangent-opensource/coreBlackbird/files/6843559/perpoint_attr.zip)

![image](https://user-images.githubusercontent.com/2072636/126218557-8e9680d5-ef2d-4dc6-8326-abcba8950df4.png)
