### PR TITLE
Added missing acceleration enumerator value in switch

### DIFF
--- a/src/render/geometry.cpp
+++ b/src/render/geometry.cpp
@@ -375,6 +375,7 @@ TypeDesc Geometry::standard_type(AttributeStandard std) const
       case ATTR_STD_POSITION_UNDISPLACED:
         return TypeDesc::TypePoint;
       case ATTR_STD_VERTEX_VELOCITY:
+      case ATTR_STD_VERTEX_ACCELERATION:
         return TypeDesc::TypeVector;
       case ATTR_STD_MOTION_VERTEX_POSITION:
         return TypeDesc::TypePoint;
@@ -483,6 +484,7 @@ AttributeElement Geometry::standard_element(AttributeStandard std) const
       case ATTR_STD_POSITION_UNDISPLACED:
         return ATTR_ELEMENT_VERTEX;
       case ATTR_STD_VERTEX_VELOCITY:
+      case ATTR_STD_VERTEX_ACCELERATION:
         return ATTR_ELEMENT_VERTEX;
       case ATTR_STD_MOTION_VERTEX_POSITION:
         return ATTR_ELEMENT_VERTEX_MOTION;


### PR DESCRIPTION
Missing values in switch, this is most likely caused by a previous merge gone wrong.