### PR TITLE
Connecting custom volume attributes

### DIFF
--- a/src/kernel/geom/geom_primitive.h
+++ b/src/kernel/geom/geom_primitive.h
@@ -47,6 +47,7 @@ ccl_device_inline float primitive_attribute_float(
     } else if (desc.element == ATTR_ELEMENT_OBJECT) {
       return kernel_tex_fetch(__attributes_float, desc.offset);
     }
+    return 0.0f;
   }
 #endif
   else {
@@ -164,6 +165,7 @@ ccl_device_inline float3 primitive_attribute_float3(KernelGlobals *kg,
     } else if (desc.element == ATTR_ELEMENT_OBJECT) {
       return float4_to_float3(kernel_tex_fetch(__attributes_float3, desc.offset));
     }
+    return make_float3(0.0f, 0.0f, 0.0f);
   }
 #endif
   else {

--- a/src/kernel/geom/geom_primitive.h
+++ b/src/kernel/geom/geom_primitive.h
@@ -91,10 +91,8 @@ ccl_device_inline float primitive_volume_attribute_float(KernelGlobals *kg,
                                                          const ShaderData *sd,
                                                          const AttributeDescriptor desc)
 {
-  if (sd->object != OBJECT_NONE) {
-    if (desc.element == ATTR_ELEMENT_VOXEL) {
-      return volume_attribute_float(kg, sd, desc);
-    }
+  if (sd->object != OBJECT_NONE && desc.element == ATTR_ELEMENT_VOXEL) {
+    return volume_attribute_float(kg, sd, desc);
   }
   else {
     return 0.0f;

--- a/src/kernel/geom/geom_primitive.h
+++ b/src/kernel/geom/geom_primitive.h
@@ -37,12 +37,16 @@ ccl_device_inline float primitive_attribute_float(
   }
 #endif
 #ifdef __VOLUME__
-  else if (sd->object != OBJECT_NONE && desc.element == ATTR_ELEMENT_VOXEL) {
+  else if (sd->object != OBJECT_NONE) {
     if (dx)
       *dx = 0.0f;
     if (dy)
       *dy = 0.0f;
-    return volume_attribute_float(kg, sd, desc);
+    if (desc.element == ATTR_ELEMENT_VOXEL) {
+      return volume_attribute_float(kg, sd, desc);
+    } else if (desc.element == ATTR_ELEMENT_OBJECT) {
+      return kernel_tex_fetch(__attributes_float, desc.offset);
+    }
   }
 #endif
   else {
@@ -87,8 +91,10 @@ ccl_device_inline float primitive_volume_attribute_float(KernelGlobals *kg,
                                                          const ShaderData *sd,
                                                          const AttributeDescriptor desc)
 {
-  if (sd->object != OBJECT_NONE && desc.element == ATTR_ELEMENT_VOXEL) {
-    return volume_attribute_float(kg, sd, desc);
+  if (sd->object != OBJECT_NONE) {
+    if (desc.element == ATTR_ELEMENT_VOXEL) {
+      return volume_attribute_float(kg, sd, desc);
+    }
   }
   else {
     return 0.0f;
@@ -150,12 +156,16 @@ ccl_device_inline float3 primitive_attribute_float3(KernelGlobals *kg,
   }
 #endif
 #ifdef __VOLUME__
-  else if (sd->object != OBJECT_NONE && desc.element == ATTR_ELEMENT_VOXEL) {
+  else if (sd->object != OBJECT_NONE) {
     if (dx)
       *dx = make_float3(0.0f, 0.0f, 0.0f);
     if (dy)
       *dy = make_float3(0.0f, 0.0f, 0.0f);
-    return volume_attribute_float3(kg, sd, desc);
+    if (desc.element == ATTR_ELEMENT_VOXEL) {
+      return volume_attribute_float3(kg, sd, desc);
+    } else if (desc.element == ATTR_ELEMENT_OBJECT) {
+      return float4_to_float3(kernel_tex_fetch(__attributes_float3, desc.offset));
+    }
   }
 #endif
   else {

--- a/src/render/attribute.cpp
+++ b/src/render/attribute.cpp
@@ -448,13 +448,16 @@ void AttributeSet::resize(bool reserve_only)
   }
 }
 
-void AttributeSet::clear(bool preserve_voxel_data)
+void AttributeSet::clear(bool preserve_voxel_data, bool preserve_custom_data)
 {
   if (preserve_voxel_data) {
     list<Attribute>::iterator it;
 
     for (it = attributes.begin(); it != attributes.end();) {
       if (it->element == ATTR_ELEMENT_VOXEL || it->std == ATTR_STD_GENERATED_TRANSFORM) {
+        it++;
+      }
+      else if (it->std == ATTR_STD_NONE) {
         it++;
       }
       else {

--- a/src/render/attribute.cpp
+++ b/src/render/attribute.cpp
@@ -450,14 +450,14 @@ void AttributeSet::resize(bool reserve_only)
 
 void AttributeSet::clear(bool preserve_voxel_data, bool preserve_custom_data)
 {
-  if (preserve_voxel_data) {
+  if (preserve_voxel_data || preserve_custom_data) {
     list<Attribute>::iterator it;
 
     for (it = attributes.begin(); it != attributes.end();) {
-      if (it->element == ATTR_ELEMENT_VOXEL || it->std == ATTR_STD_GENERATED_TRANSFORM) {
+      if (preserve_voxel_data && (it->element == ATTR_ELEMENT_VOXEL || it->std == ATTR_STD_GENERATED_TRANSFORM)) {
         it++;
       }
-      else if (it->std == ATTR_STD_NONE) {
+      else if (preserve_custom_data && it->std == ATTR_STD_NONE) {
         it++;
       }
       else {

--- a/src/render/attribute.h
+++ b/src/render/attribute.h
@@ -192,7 +192,7 @@ class AttributeSet {
   void remove(Attribute *attribute);
 
   void resize(bool reserve_only = false);
-  void clear(bool preserve_voxel_data = false);
+  void clear(bool preserve_voxel_data = false, bool preserve_custom_data = false);
 };
 
 /* AttributeRequest

--- a/src/render/mesh.cpp
+++ b/src/render/mesh.cpp
@@ -212,7 +212,7 @@ void Mesh::reserve_subd_faces(int numfaces, int num_ngons_, int numcorners)
   subd_attributes.resize(true);
 }
 
-void Mesh::clear(bool preserve_voxel_data)
+void Mesh::clear(bool preserve_voxel_data, bool preserve_custom_data)
 {
   Geometry::clear();
 
@@ -233,7 +233,7 @@ void Mesh::clear(bool preserve_voxel_data)
   subd_creases.clear();
 
   subd_attributes.clear();
-  attributes.clear(preserve_voxel_data);
+  attributes.clear(preserve_voxel_data, preserve_custom_data);
 
   vert_to_stitching_key_map.clear();
   vert_stitching_map.clear();

--- a/src/render/mesh.h
+++ b/src/render/mesh.h
@@ -177,7 +177,7 @@ class Mesh : public Geometry {
   void reserve_mesh(int numverts, int numfaces);
   void resize_subd_faces(int numfaces, int num_ngons, int numcorners);
   void reserve_subd_faces(int numfaces, int num_ngons, int numcorners);
-  void clear(bool preserve_voxel_data);
+  void clear(bool preserve_voxel_data, bool preserve_custom_data = false);
   void clear() override;
   void add_vertex(float3 P);
   void add_vertex_slow(float3 P);

--- a/src/render/mesh_volume.cpp
+++ b/src/render/mesh_volume.cpp
@@ -537,7 +537,7 @@ void GeometryManager::create_volume_mesh(Mesh *mesh, Progress &progress)
   vector<float3> face_normals;
   builder.create_mesh(vertices, indices, face_normals, face_overlap_avoidance);
 
-  mesh->clear(true);
+  mesh->clear(true, true);
   mesh->reserve_mesh(vertices.size(), indices.size() / 3);
   mesh->used_shaders.push_back(volume_shader);
   mesh->need_update_rebuild = true;


### PR DESCRIPTION
**Description**
If you connect an AttributeNode with a non standard attribute name to a Principled Volume, Volume Scatter or similar, the value (float or float3) is not being read by the shader.
Constant attributes [are not read](https://github.com/tangent-opensource/coreBlackbird/blob/master/src/kernel/geom/geom_volume.h#L69) when shading a volume, this PR makes `primitive_attribute_float*` in the volume case behave similarly to meshes or other primitives.

Does this make sense?  I am not aware of all the intricacies of reading attributes from shaders. Being limited to custom attribute names seems a good middle ground between complex workarounds and not breaking the core semantics.

Unfortunately, if the name matches one of the standard attributes, [it is not possible to overwrite it](https://github.com/tangent-opensource/coreBlackbird/blob/master/src/render/nodes.cpp#L5563) as it is resolved to an `ATTR_STD_ELEMENT_VOXEL` which only reads from an image/nanovdb. Essentially, I seem to understand that standard attributes have fixed interpolation (element). 
In theory you could work around it through textures, but that seems unnecessary and not friendly to per instance overrides. 

**Changes**
- Preserving non standard attributes when the mesh is created from the volume
- Reading constant attributes in volume kernels

**Reference**
Please see FD-8574 